### PR TITLE
fix vuepress-plugin-mathjax can not support '\begin{aligned}' problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "lru-cache": "^5.1.1",
-    "mathjax3": "3.0.0-beta.3",
+    "mathjax-full": "3.0.0",
     "vuepress-mergeable": "^1.0.2"
   },
   "keywords": [

--- a/src/tex2html.js
+++ b/src/tex2html.js
@@ -71,6 +71,7 @@ module.exports = (options, tempPath) => {
         ),
         '../mathjax2/css',
       ),
+      adaptiveCSS: false
     })
 
   const adaptor = liteAdaptor()

--- a/src/tex2html.js
+++ b/src/tex2html.js
@@ -2,13 +2,13 @@ const url = require('url')
 const path = require('path')
 const LruCache = require('lru-cache')
 
-const { TeX } = require('mathjax3/mathjax3/input/tex')
-const { SVG } = require('mathjax3/mathjax3/output/svg')
-const { CHTML } = require('mathjax3/mathjax3/output/chtml')
-const { HTMLDocument } = require('mathjax3/mathjax3/handlers/html/HTMLDocument')
-const { liteAdaptor } = require('mathjax3/mathjax3/adaptors/liteAdaptor')
-const { LiteDocument } = require('mathjax3/mathjax3/adaptors/lite/Document')
-const { AllPackages } = require('mathjax3/mathjax3/input/tex/AllPackages')
+const { TeX } = require('mathjax-full/js/input/tex')
+const { SVG } = require('mathjax-full/js/output/svg')
+const { CHTML } = require('mathjax-full/js/output/chtml')
+const { liteAdaptor } = require('mathjax-full/js/adaptors/liteAdaptor')
+const { AllPackages } = require('mathjax-full/js/input/tex/AllPackages')
+const { RegisterHTMLHandler } = require('mathjax-full/js/handlers/html.js')
+const { mathjax } = require('mathjax-full/js/mathjax.js')
 
 const escapedCharacters = '^$()[]{}*.?+\\|'
 

--- a/src/tex2html.js
+++ b/src/tex2html.js
@@ -7,6 +7,7 @@ const { SVG } = require('mathjax-full/js/output/svg')
 const { CHTML } = require('mathjax-full/js/output/chtml')
 const { liteAdaptor } = require('mathjax-full/js/adaptors/liteAdaptor')
 const { AllPackages } = require('mathjax-full/js/input/tex/AllPackages')
+const { LiteDocument } = require('mathjax-full/js/adaptors/lite/Document')
 const { RegisterHTMLHandler } = require('mathjax-full/js/handlers/html.js')
 const { mathjax } = require('mathjax-full/js/mathjax.js')
 
@@ -67,24 +68,22 @@ module.exports = (options, tempPath) => {
       fontURL: url.resolve(
         path.relative(
           tempPath,
-          require.resolve('mathjax3')
+          require.resolve('mathjax-full')
         ),
-        '../mathjax2/css',
+        '../../../es5/output/chtml/fonts/woff-v2',
       ),
       adaptiveCSS: false
     })
 
   const adaptor = liteAdaptor()
-  const html = new HTMLDocument(new LiteDocument(), adaptor, {
-    InputJax,
-    OutputJax,
-  })
+  RegisterHTMLHandler(adaptor);
 
+  const html = mathjax.document(new LiteDocument(), {InputJax: InputJax, OutputJax: OutputJax});
   let style = adaptor.textContent(OutputJax.styleSheet(html))
 
   // https://github.com/mathjax/mathjax-v3/pull/256
   style = style.replace(/\bwhite space\b/g, 'white-space')
-
+  console.log(style)
   return {
     style,
     render (source, display, localPresets) {


### PR DESCRIPTION
vuepress-plugin-mathjax with dependency 'mathjax3' can not support just like '\begin{aligned}' expression. I have tried to change the dependency into 'mathjax-full', and it worked fine.
The chtml configure options need to add 'adaptive: false', to include the whole css file in mathjax.